### PR TITLE
fix: add missing code block in tutorial/orders

### DIFF
--- a/samples/orders.kt
+++ b/samples/orders.kt
@@ -5,8 +5,19 @@ import org.roboquant.brokers.sim.Pricing
 import org.roboquant.common.Asset
 import org.roboquant.common.Size
 import org.roboquant.orders.*
+import org.roboquant.strategies.Signal
 import java.time.Instant
 
+fun signal2order(signals: List<Signal>) {
+    // tag::orders[]
+    val orders = mutableListOf<Order>()
+    for (signal in signals) {
+        val size = if (signal.rating.isPositive) 100 else -100
+        val order = MarketOrder(signal.asset, size)
+        orders.add(order)
+    }
+    // end::orders[]
+}
 
 fun bracketOrder(asset: Asset, price: Double) {
     // tag::bracketOrder[]

--- a/samples/policy.kt
+++ b/samples/policy.kt
@@ -137,15 +137,3 @@ fun noStrategy(myAdvancedPolicy: Policy) {
     val roboquant = Roboquant(NoSignalStrategy(), policy = myAdvancedPolicy)
     // end::advanced[]
 }
-
-fun signal2order(signals: List<Signal>) {
-    // tag::orders[]
-    val orders = mutableListOf<Order>()
-    for (signal in signals) {
-        val size = if (signal.rating.isPositive) 100 else -100
-        val order = MarketOrder(signal.asset, size)
-        orders.add(order)
-    }
-    // end::orders[]
-}
-


### PR DESCRIPTION
Hi,
I moved the function with orders tag from the policy page to the orders page in order for the tag to be recognized in the correct page.
It should fix #2 